### PR TITLE
fix link to repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "lightcrawler",
   "version": "0.0.9",
   "description": "",
+  "repository": "github/lightcrawler",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Noticed this package was missing a link from npm to GitHub. Also worth noting
that there's no link License attached anywhere; might be worth adding at some
point in the future. Thanks!